### PR TITLE
refactor: replace @slf4j with runContext.logger()

### DIFF
--- a/src/main/java/io/kestra/plugin/supabase/AbstractSupabase.java
+++ b/src/main/java/io/kestra/plugin/supabase/AbstractSupabase.java
@@ -7,11 +7,9 @@ import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import lombok.extern.slf4j.Slf4j;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -24,14 +22,13 @@ import java.util.Map;
 /**
  * Abstract base class for Supabase tasks providing common functionality.
  */
-@Slf4j
 @SuperBuilder
 @ToString
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
 public abstract class AbstractSupabase extends Task implements SupabaseInterface {
-    
+
     @NotNull
     protected Property<String> url;
 
@@ -61,7 +58,7 @@ public abstract class AbstractSupabase extends Task implements SupabaseInterface
         String renderedUrl = runContext.render(this.url).as(String.class).orElseThrow();
         String renderedApiKey = runContext.render(this.apiKey).as(String.class).orElseThrow();
         String renderedSchema = runContext.render(this.schema).as(String.class).orElse("public");
-        
+
         // Ensure URL ends with /rest/v1 for the REST API
         if (!renderedUrl.endsWith("/rest/v1")) {
             if (renderedUrl.endsWith("/")) {
@@ -70,9 +67,9 @@ public abstract class AbstractSupabase extends Task implements SupabaseInterface
                 renderedUrl = renderedUrl + "/rest/v1";
             }
         }
-        
+
         String fullUrl = renderedUrl + endpoint;
-        
+
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("apikey", List.of(renderedApiKey));
         headers.put("Authorization", List.of("Bearer " + renderedApiKey));


### PR DESCRIPTION
This PR removes unused `@Slf4j` annotations and uses execution-specific `runContext.logger()` where applicable. This aligns the plugin with project-wide logging conventions.

### What changes are being made and why?

- Removed unused `@Slf4j` annotations


Related to kestra-io/kestra#12770

***

### How the changes have been QAed?

✅ Code compiles with no errors or warnings
✅ No functional changes - refactoring only