### PR TITLE
fix: remove invalid @PluginProperty annotation inside method body

### DIFF
--- a/src/main/java/io/kestra/plugin/supabase/Insert.java
+++ b/src/main/java/io/kestra/plugin/supabase/Insert.java
@@ -226,7 +226,6 @@ public class Insert extends AbstractSupabase implements RunnableTask<Insert.Outp
 
     @Override
     public Object getFrom() {
-        @PluginProperty(group = "main")
         return getData();
     }
 


### PR DESCRIPTION
Remove `@PluginProperty(group = "main")` that was incorrectly inserted inside the `getFrom()` method body before the `return` statement in `Insert.java`. This caused a compilation error.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712